### PR TITLE
RGBoard Program: First Iteration 

### DIFF
--- a/rgboard/Makefile
+++ b/rgboard/Makefile
@@ -1,0 +1,31 @@
+# Compiler settings
+CXX = g++
+CXXFLAGS=-Wall -O3 -g -Wextra -Wno-unused-parameter
+
+# Source files and executable
+SRCS = src/main.cpp
+OBJECTS = $(SRCS:.cpp=.o)
+BINARIES = rgboard
+
+# Where our library resides
+RGB_LIB_DISTRIBUTION=..
+RGB_INCDIR=$(RGB_LIB_DISTRIBUTION)/include
+RGB_LIBDIR=$(RGB_LIB_DISTRIBUTION)/lib
+RGB_LIBRARY_NAME=rgbmatrix
+RGB_LIBRARY=$(RGB_LIBDIR)/lib$(RGB_LIBRARY_NAME).a
+LDFLAGS+=-L$(RGB_LIBDIR) -l$(RGB_LIBRARY_NAME) -lrt -lm -lpthread
+
+# Default target: Build the executable
+all: $(BINARIES)
+
+# Compile .o files
+src/%.o: src/%.cpp
+	$(CXX) $(CXXFLAGS) -I$(RGB_INCDIR) -c -o $@ $<
+
+# Link everything into the final executable
+rgboard: $(OBJECTS) $(RGB_LIBRARY)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJECTS) $(LDFLAGS)
+
+# Clean up build files
+clean:
+	rm -f src/*.o $(BINARIES)

--- a/rgboard/Makefile
+++ b/rgboard/Makefile
@@ -1,31 +1,35 @@
 # Compiler settings
 CXX = g++
-CXXFLAGS=-Wall -O3 -g -Wextra -Wno-unused-parameter
+CXXFLAGS = -Wall -O3 -g -Wextra -Wno-unused-parameter
 
 # Source files and executable
-SRCS = src/main.cpp src/display.cpp
+SRCS = src/main.cpp src/display.cpp src/queue-client.cpp
 OBJECTS = $(SRCS:.cpp=.o)
 BINARIES = rgboard
 
-# Where our library resides
-RGB_LIB_DISTRIBUTION=..
-RGB_INCDIR=$(RGB_LIB_DISTRIBUTION)/include
-RGB_LIBDIR=$(RGB_LIB_DISTRIBUTION)/lib
-RGB_LIBRARY_NAME=rgbmatrix
-RGB_LIBRARY=$(RGB_LIBDIR)/lib$(RGB_LIBRARY_NAME).a
-LDFLAGS+=-L$(RGB_LIBDIR) -l$(RGB_LIBRARY_NAME) -lrt -lm -lpthread
+# Where our RGB library resides
+RGB_LIB_DISTRIBUTION = ..
+RGB_INCDIR = $(RGB_LIB_DISTRIBUTION)/include
+RGB_LIBDIR = $(RGB_LIB_DISTRIBUTION)/lib
+RGB_LIBRARY_NAME = rgbmatrix
+RGB_LIBRARY = $(RGB_LIBDIR)/lib$(RGB_LIBRARY_NAME).a
 
-# Default target: Build the executable
+# Linker flags: add libcurl and jsoncpp
+LDFLAGS += -L$(RGB_LIBDIR) -l$(RGB_LIBRARY_NAME) -lcurl -ljsoncpp -lrt -lm -lpthread
+
+# Default target
 all: $(BINARIES)
 
 # Compile .o files
 src/%.o: src/%.cpp
 	$(CXX) $(CXXFLAGS) -Iinclude -I$(RGB_INCDIR) -c -o $@ $<
 
-# Link everything into the final executable
+# Link final binary
 rgboard: $(OBJECTS) $(RGB_LIBRARY)
 	$(CXX) $(CXXFLAGS) -o $@ $(OBJECTS) $(LDFLAGS)
 
-# Clean up build files
+# Clean up
 clean:
 	rm -f src/*.o $(BINARIES)
+
+.PHONY: all clean

--- a/rgboard/Makefile
+++ b/rgboard/Makefile
@@ -3,7 +3,7 @@ CXX = g++
 CXXFLAGS=-Wall -O3 -g -Wextra -Wno-unused-parameter
 
 # Source files and executable
-SRCS = src/main.cpp
+SRCS = src/main.cpp src/display.cpp
 OBJECTS = $(SRCS:.cpp=.o)
 BINARIES = rgboard
 
@@ -20,7 +20,7 @@ all: $(BINARIES)
 
 # Compile .o files
 src/%.o: src/%.cpp
-	$(CXX) $(CXXFLAGS) -I$(RGB_INCDIR) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -Iinclude -I$(RGB_INCDIR) -c -o $@ $<
 
 # Link everything into the final executable
 rgboard: $(OBJECTS) $(RGB_LIBRARY)

--- a/rgboard/include/display.h
+++ b/rgboard/include/display.h
@@ -1,0 +1,17 @@
+//
+// Created by evalentin on 09/03/25.
+//
+
+#ifndef DISPLAY_H
+#define DISPLAY_H
+
+#include "led-matrix.h"
+
+#include <unistd.h>
+#include <signal.h>
+#include <math.h>
+
+using rgb_matrix::RGBMatrix;
+using rgb_matrix::Canvas;
+void DrawOnCanvas(Canvas *canvas);
+#endif //DISPLAY_H

--- a/rgboard/include/display.h
+++ b/rgboard/include/display.h
@@ -7,11 +7,9 @@
 
 #include "led-matrix.h"
 
-#include <unistd.h>
-#include <signal.h>
-#include <math.h>
+#include <jsoncpp/json/json.h> // JSON parsing
 
 using rgb_matrix::RGBMatrix;
 using rgb_matrix::Canvas;
-void DrawOnCanvas(Canvas *canvas);
+void DrawDesignOnCanvas(Canvas* canvas, const Json::Value& pixel_data);
 #endif //DISPLAY_H

--- a/rgboard/include/queue-client.h
+++ b/rgboard/include/queue-client.h
@@ -1,0 +1,23 @@
+//
+// Created by evalentin on 01/05/25.
+//
+
+#ifndef QUEUE_CLIENT_H
+#define QUEUE_CLIENT_H
+#include <string>
+
+class QueueClient
+{
+public:
+    QueueClient(std::string email, std::string password);
+    std::string GetDesign();
+
+private:
+    std::string jwt;
+    std::string email;
+    std::string password;
+
+    std::string GetJWT();
+    static size_t CurlWriteCallback(void* contents, size_t size, size_t nmemb, std::string* output);
+};
+#endif //QUEUE_CLIENT_H

--- a/rgboard/include/queue-client.h
+++ b/rgboard/include/queue-client.h
@@ -5,17 +5,24 @@
 #ifndef QUEUE_CLIENT_H
 #define QUEUE_CLIENT_H
 #include <string>
+#include <jsoncpp/json/json.h>
 
 class QueueClient
 {
 public:
     QueueClient(std::string email, std::string password);
-    std::string GetDesign();
+    bool GetDesign();
+    [[nodiscard]] int GetDisplayDuration() const;
+    Json::Value GetPixelData();
 
 private:
     std::string jwt;
     std::string email;
     std::string password;
+
+    // We store in these variables and get from here. Can't return a string and an int in the same function.
+    int display_duration{};
+    Json::Value pixel_data;
 
     std::string GetJWT();
     static size_t CurlWriteCallback(void* contents, size_t size, size_t nmemb, std::string* output);

--- a/rgboard/src/display.cpp
+++ b/rgboard/src/display.cpp
@@ -3,26 +3,56 @@
 //
 
 #include "../include/display.h"
+#include <string>              // std::string
+#include <sstream>             // std::stringstream, std::istringstream
+#include <iostream>            // std::cerr, std::cout
+
 
 using rgb_matrix::RGBMatrix;
 using rgb_matrix::Canvas;
 
+void HexToRGB(const std::string& hex, int& r, int& g, int& b);
 
-void DrawOnCanvas(Canvas *canvas) {
-    /*
-     * Let's create a simple animation. We use the canvas to draw
-     * pixels. We wait between each step to have a slower animation.
-     */
-    canvas->Fill(0, 255, 0);
+void DrawDesignOnCanvas(Canvas* canvas, const Json::Value& pixel_data)
+{
+    constexpr int GRID_SIZE = 8; // pixel data is 8x scaled
+    canvas->Clear();
 
-    int center_x = canvas->width() / 2;
-    int center_y = canvas->height() / 2;
-    float radius_max = canvas->width() / 2;
-    float angle_step = 1.0 / 360;
-    for (float a = 0, r = 0; r < radius_max; a += angle_step, r += angle_step) {
-        float dot_x = cos(a * 2 * M_PI) * r;
-        float dot_y = sin(a * 2 * M_PI) * r;
-        canvas->SetPixel(center_x + dot_x, center_y + dot_y, 0, 0, 40);
-        usleep(1 * 1000); // wait a little to slow down things.
+    for (const auto& key : pixel_data.getMemberNames())
+    {
+        int x = 0, y = 0;
+        char comma;
+
+        std::stringstream coord_stream(key);
+        coord_stream >> x >> comma >> y;
+
+        // downscale
+        x /= GRID_SIZE;
+        y /= GRID_SIZE;
+
+        const std::string hex_color = pixel_data[key].asString();
+        int r, g, b;
+        HexToRGB(hex_color, r, g, b);
+
+        if (x >= 0 && x < canvas->width() && y >= 0 && y < canvas->height())
+        {
+            canvas->SetPixel(x, y, r, g, b);
+        }
+    }
+}
+
+
+// Convert hex string to RGB integers
+void HexToRGB(const std::string& hex, int& r, int& g, int& b)
+{
+    if (hex.length() == 7 && hex[0] == '#')
+    {
+        r = std::stoi(hex.substr(1, 2), nullptr, 16);
+        g = std::stoi(hex.substr(3, 2), nullptr, 16);
+        b = std::stoi(hex.substr(5, 2), nullptr, 16);
+    }
+    else
+    {
+        r = g = b = 0; // fallback to black
     }
 }

--- a/rgboard/src/display.cpp
+++ b/rgboard/src/display.cpp
@@ -1,0 +1,28 @@
+//
+// Created by evalentin on 09/03/25.
+//
+
+#include "../include/display.h"
+
+using rgb_matrix::RGBMatrix;
+using rgb_matrix::Canvas;
+
+
+void DrawOnCanvas(Canvas *canvas) {
+    /*
+     * Let's create a simple animation. We use the canvas to draw
+     * pixels. We wait between each step to have a slower animation.
+     */
+    canvas->Fill(0, 255, 0);
+
+    int center_x = canvas->width() / 2;
+    int center_y = canvas->height() / 2;
+    float radius_max = canvas->width() / 2;
+    float angle_step = 1.0 / 360;
+    for (float a = 0, r = 0; r < radius_max; a += angle_step, r += angle_step) {
+        float dot_x = cos(a * 2 * M_PI) * r;
+        float dot_y = sin(a * 2 * M_PI) * r;
+        canvas->SetPixel(center_x + dot_x, center_y + dot_y, 0, 0, 40);
+        usleep(1 * 1000); // wait a little to slow down things.
+    }
+}

--- a/rgboard/src/main.cpp
+++ b/rgboard/src/main.cpp
@@ -8,32 +8,9 @@
 #define HARDWARE "regular"
 #define GPIO_SLOWDOWN 4
 
-#include  "display.h"
-
+#include "queue-client.h"
 
 int main(int argc, char *argv[]){
-    RGBMatrix::Options defaults;
-    rgb_matrix::RuntimeOptions runtime_options;
-
-    defaults.hardware_mapping = HARDWARE;  // or e.g. "adafruit-hat"
-    defaults.rows = ROWS;
-    defaults.cols = COLS;
-    defaults.parallel = PARALLEL;
-
-    runtime_options.gpio_slowdown = GPIO_SLOWDOWN;
-
-    Canvas *canvas = RGBMatrix::CreateFromOptions(defaults, runtime_options);
-
-    if (canvas == NULL)
-        return 1;
-
-
-    DrawOnCanvas(canvas);    // Using the canvas.
-
-    // Animation finished. Shut down the RGB matrix.
-    canvas->Clear();
-    delete canvas;
-
-    return 0;
+    auto client = QueueClient("abc", "123");
     return 0;
 }

--- a/rgboard/src/main.cpp
+++ b/rgboard/src/main.cpp
@@ -8,9 +8,53 @@
 #define HARDWARE "regular"
 #define GPIO_SLOWDOWN 4
 
-#include "queue-client.h"
+#include <unistd.h>
 
-int main(int argc, char *argv[]){
-    auto client = QueueClient("abc", "123");
+#include "queue-client.h"
+#include "display.h"
+
+int main(int argc, char* argv[])
+{
+    // Matrix configuration
+    rgb_matrix::RGBMatrix::Options defaults;
+    rgb_matrix::RuntimeOptions runtime_options;
+
+    defaults.hardware_mapping = HARDWARE;
+    defaults.rows = ROWS;
+    defaults.cols = COLS;
+    defaults.parallel = PARALLEL;
+
+    runtime_options.gpio_slowdown = GPIO_SLOWDOWN;
+
+    // Initialize matrix
+    rgb_matrix::Canvas* canvas = rgb_matrix::CreateMatrixFromOptions(defaults, runtime_options);
+    if (canvas == nullptr)
+    {
+        std::fprintf(stderr, "Failed to initialize matrix.\n");
+        return 1;
+    }
+
+    // Authenticate with client
+    QueueClient client("email", "password");
+
+    // main loop: fetch + draw + wait
+    while (true)
+    {
+        if (client.GetDesign())
+        {
+            const Json::Value& pixel_data = client.GetPixelData();
+            int duration = client.GetDisplayDuration();
+
+            DrawDesignOnCanvas(canvas, pixel_data);
+            std::printf("Displaying design for %d seconds.\n", duration);
+            sleep(duration);
+        }
+        else
+        {
+            std::fprintf(stderr, "Failed to get design. Retrying in 5 seconds...\n");
+            sleep(5);
+        }
+    }
+
     return 0;
 }

--- a/rgboard/src/main.cpp
+++ b/rgboard/src/main.cpp
@@ -2,64 +2,31 @@
 // Created by evalentin on 08/03/25.
 //
 
-#include "led-matrix.h"
+#define ROWS 32
+#define COLS 64
+#define PARALLEL 2
+#define HARDWARE "regular"
+#define GPIO_SLOWDOWN 4
 
-#include <math.h>
-#include <unistd.h>
-#include <signal.h>
-
-
-using rgb_matrix::RGBMatrix;
-using rgb_matrix::Canvas;
-
-volatile bool interrupt_received = false;
-static void InterruptHandler(int signo) {
-    interrupt_received = true;
-}
-
-
-static void DrawOnCanvas(Canvas *canvas) {
-    /*
-     * Let's create a simple animation. We use the canvas to draw
-     * pixels. We wait between each step to have a slower animation.
-     */
-    canvas->Fill(0, 0, 255);
-
-    int center_x = canvas->width() / 2;
-    int center_y = canvas->height() / 2;
-    float radius_max = canvas->width() / 2;
-    float angle_step = 1.0 / 360;
-    for (float a = 0, r = 0; r < radius_max; a += angle_step, r += angle_step) {
-        if (interrupt_received)
-            return;
-        float dot_x = cos(a * 2 * M_PI) * r;
-        float dot_y = sin(a * 2 * M_PI) * r;
-        canvas->SetPixel(center_x + dot_x, center_y + dot_y, 255, 0, 0);
-        usleep(1 * 1000); // wait a little to slow down things.
-    }
-}
+#include  "display.h"
 
 
 int main(int argc, char *argv[]){
     RGBMatrix::Options defaults;
-    defaults.hardware_mapping = "regular";
-    defaults.rows = 32;
-    defaults.chain_length = 1;
-    defaults.parallel = 2;
-    defaults.show_refresh_rate = true;
+    rgb_matrix::RuntimeOptions runtime_options;
 
-    Canvas * canvas = RGBMatrix::CreateFromFlags(&argc, &argv, &defaults);
+    defaults.hardware_mapping = HARDWARE;  // or e.g. "adafruit-hat"
+    defaults.rows = ROWS;
+    defaults.cols = COLS;
+    defaults.parallel = PARALLEL;
+
+    runtime_options.gpio_slowdown = GPIO_SLOWDOWN;
+
+    Canvas *canvas = RGBMatrix::CreateFromOptions(defaults, runtime_options);
 
     if (canvas == NULL)
-    {
         return 1;
-    }
 
-    // It is always good to set up a signal handler to cleanly exit when we
-    // receive a CTRL-C for instance. The DrawOnCanvas() routine is looking
-    // for that.
-    signal(SIGTERM, InterruptHandler);
-    signal(SIGINT, InterruptHandler);
 
     DrawOnCanvas(canvas);    // Using the canvas.
 
@@ -67,5 +34,6 @@ int main(int argc, char *argv[]){
     canvas->Clear();
     delete canvas;
 
+    return 0;
     return 0;
 }

--- a/rgboard/src/main.cpp
+++ b/rgboard/src/main.cpp
@@ -1,0 +1,71 @@
+//
+// Created by evalentin on 08/03/25.
+//
+
+#include "led-matrix.h"
+
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+
+using rgb_matrix::RGBMatrix;
+using rgb_matrix::Canvas;
+
+volatile bool interrupt_received = false;
+static void InterruptHandler(int signo) {
+    interrupt_received = true;
+}
+
+
+static void DrawOnCanvas(Canvas *canvas) {
+    /*
+     * Let's create a simple animation. We use the canvas to draw
+     * pixels. We wait between each step to have a slower animation.
+     */
+    canvas->Fill(0, 0, 255);
+
+    int center_x = canvas->width() / 2;
+    int center_y = canvas->height() / 2;
+    float radius_max = canvas->width() / 2;
+    float angle_step = 1.0 / 360;
+    for (float a = 0, r = 0; r < radius_max; a += angle_step, r += angle_step) {
+        if (interrupt_received)
+            return;
+        float dot_x = cos(a * 2 * M_PI) * r;
+        float dot_y = sin(a * 2 * M_PI) * r;
+        canvas->SetPixel(center_x + dot_x, center_y + dot_y, 255, 0, 0);
+        usleep(1 * 1000); // wait a little to slow down things.
+    }
+}
+
+
+int main(int argc, char *argv[]){
+    RGBMatrix::Options defaults;
+    defaults.hardware_mapping = "regular";
+    defaults.rows = 32;
+    defaults.chain_length = 1;
+    defaults.parallel = 2;
+    defaults.show_refresh_rate = true;
+
+    Canvas * canvas = RGBMatrix::CreateFromFlags(&argc, &argv, &defaults);
+
+    if (canvas == NULL)
+    {
+        return 1;
+    }
+
+    // It is always good to set up a signal handler to cleanly exit when we
+    // receive a CTRL-C for instance. The DrawOnCanvas() routine is looking
+    // for that.
+    signal(SIGTERM, InterruptHandler);
+    signal(SIGINT, InterruptHandler);
+
+    DrawOnCanvas(canvas);    // Using the canvas.
+
+    // Animation finished. Shut down the RGB matrix.
+    canvas->Clear();
+    delete canvas;
+
+    return 0;
+}

--- a/rgboard/src/queue-client.cpp
+++ b/rgboard/src/queue-client.cpp
@@ -1,0 +1,112 @@
+//
+// Created by evalentin on 01/05/25.
+//
+
+#include "../include/queue-client.h"
+#include <curl/curl.h>
+#include <jsoncpp/json/json.h>
+#include <cstdlib>
+
+#define LOGIN_URL "http://localhost:5000/login"
+
+
+QueueClient::QueueClient(std::string email, std::string password)
+{
+    this->email = std::move(email);
+    this->password = std::move(password);
+    jwt = GetJWT();
+}
+
+
+std::string QueueClient::GetJWT()
+{
+    if (this->email.empty())
+    {
+        std::printf("Email field is empty.\n");
+        return "";
+    }
+    else if (password.empty())
+    {
+        std::printf("Password field is empty.\n");
+        return "";
+    }
+
+    CURL* curl = curl_easy_init();
+
+    if (!curl)
+    {
+        printf("Curl init failed\n");
+        return "";
+    }
+
+    std::string response;
+    Json::Value body;
+
+    // Doing this in C++ is crazy, even the IDE is confused.
+    body["email"] = this->email;
+    body["password"] = this->password;
+
+    Json::StreamWriterBuilder writer;
+
+    std::string json_body = Json::writeString(writer, body);
+
+    struct curl_slist* headers = nullptr;
+
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    // Set options
+    curl_easy_setopt(curl, CURLOPT_URL, LOGIN_URL);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_body.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    // Send request
+    CURLcode result = curl_easy_perform(curl);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (result != CURLE_OK)
+    {
+        fprintf(stderr, "problem: %s\n", curl_easy_strerror(result));
+        return "";
+    }
+
+    Json::CharReaderBuilder reader;
+    Json::Value json_response;
+    std::string errs;
+
+    std::istringstream s(response);
+
+    if (!Json::parseFromStream(reader, s, &json_response, &errs))
+    {
+        printf("Failed to parse response JSON:  %s\n", errs.c_str());
+        return "";
+    }
+
+    if (json_response.isMember("access_token"))
+    {
+        std::string token = json_response["access_token"].asString();
+        return token;
+    }
+
+        std::string error_message = json_response["error"].asString();
+        printf("Login failed: no token in response.\nError: %s\n", error_message.c_str());
+        return "";
+}
+
+std::string QueueClient::GetDesign()
+{
+
+    if (this->jwt.empty())
+    {
+        return "";
+    }
+}
+
+size_t QueueClient::CurlWriteCallback(void* contents, size_t size, size_t nmemb, std::string* output)
+{
+    size_t total = size * nmemb;
+    output->append((char*)contents, total);
+    return total;
+}


### PR DESCRIPTION
This pull request introduces a new RGB LED matrix display application (`rgboard`) that integrates with a queue-based backend to fetch and render designs. The changes include the addition of a `Makefile` for build automation, new header and source files for core functionality, and a main program to tie everything together.

### Build System
* Added a `Makefile` to define build rules, including compiler settings, source files, and linking with external libraries (`libcurl`, `jsoncpp`, and the RGB matrix library).

### Core Functionality
* Introduced `QueueClient` in `queue-client.h` and `queue-client.cpp` to handle authentication and design retrieval from a backend API. This includes methods for obtaining a JWT token, fetching designs, and parsing JSON responses. [[1]](diffhunk://#diff-f7c039c12651aafdd2b44b1516f517f8f121ee0c3cf3cbf4a7ef96def99827e7R1-R30) [[2]](diffhunk://#diff-b1b24da770476dd99cd2ad5b5a38847665e1d98a5455d98a82b025fc541523eaR1-R223)
* Added `display.h` and `display.cpp` to handle rendering of pixel designs onto the RGB matrix. Includes a utility function to convert hex color codes to RGB values and a function to draw designs on the canvas. [[1]](diffhunk://#diff-5777dcbb5fa0b2dd590f4a625fcb6a93b9741484da457c0d2e9ad5aa326827bdR1-R15) [[2]](diffhunk://#diff-42f2ed72c41a510b8d0cfbc2adc631c9a7374b4d55debfc159b81cec3955f23cR1-R58)

### Main Program
* Implemented `main.cpp` to initialize the RGB matrix, authenticate with the backend, and continuously fetch and display designs in a loop. Includes error handling for failed API calls and matrix initialization.

## To: @irsaris @PinkSylvie @Jandel7 
This is so you guys can review and see what's going on internally. Please feel free to make any comments or ask questions.